### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pywikibase/claim.py
+++ b/pywikibase/claim.py
@@ -217,8 +217,7 @@ class Claim(Property):
         """
         value_class = self.types[self.type]
         if not isinstance(value, value_class):
-            raise ValueError("%s is not type %s."
-                             % (value, value_class))
+            raise ValueError("{0!s} is not type {1!s}.".format(value, value_class))
         self.target = value
 
     def getTarget(self):
@@ -405,8 +404,7 @@ class Claim(Property):
         elif self.type in ('globe-coordinate', 'time', 'quantity'):
             value = self.getTarget().toWikibase()
         else:
-            raise NotImplementedError('%s datatype is not supported yet.'
-                                      % self.type)
+            raise NotImplementedError('{0!s} datatype is not supported yet.'.format(self.type))
         return value
 
     def _formatDataValue(self):

--- a/pywikibase/coordinate.py
+++ b/pywikibase/coordinate.py
@@ -61,9 +61,9 @@ class Coordinate(object):
         self.site = site
 
     def __repr__(self):
-        string = 'Coordinate(%s, %s' % (self.lat, self.lon)
+        string = 'Coordinate({0!s}, {1!s}'.format(self.lat, self.lon)
         if self.globe != 'earth':
-            string += ', globe="%s"' % self.globe
+            string += ', globe="{0!s}"'.format(self.globe)
         string += ')'
         return string
 
@@ -84,8 +84,7 @@ class Coordinate(object):
         """
         if not self._entity and self.globe not in self.site.globes():
             raise CoordinateGlobeUnknownException(
-                u"%s is not supported in Wikibase yet."
-                % self.globe)
+                u"{0!s} is not supported in Wikibase yet.".format(self.globe))
         return {'latitude': self.lat,
                 'longitude': self.lon,
                 'altitude': self.alt,

--- a/pywikibase/itempage.py
+++ b/pywikibase/itempage.py
@@ -37,8 +37,7 @@ class ItemPage(WikibasePage):
         # Validate the title is 'Q' and a positive integer.
         if title and not re.match(r'^Q[1-9]\d*$', title):
             raise RuntimeError(
-                u"'%s' is not a valid item page title"
-                % title)
+                u"'{0!s}' is not a valid item page title".format(title))
         self.id = title
 
     def get(self, *args, **kwargs):

--- a/pywikibase/propertypage.py
+++ b/pywikibase/propertypage.py
@@ -34,7 +34,7 @@ class PropertyPage(WikibasePage, Property):
         """
         if not title.startswith('P'):
             raise ValueError(
-                u"'%s' is not an property page title" % title)
+                u"'{0!s}' is not an property page title".format(title))
         self.id = title
         Property.__init__(self, self.id, datatype)
 

--- a/pywikibase/wbtime.py
+++ b/pywikibase/wbtime.py
@@ -90,7 +90,7 @@ class WbTime(object):
             elif precision in self.PRECISION:
                 self.precision = self.PRECISION[precision]
             else:
-                raise ValueError('Invalid precision: "%s"' % precision)
+                raise ValueError('Invalid precision: "{0!s}"'.format(precision))
 
     @classmethod
     def fromTimestr(cls, datetimestr, precision=14, before=0, after=0,
@@ -98,7 +98,7 @@ class WbTime(object):
         match = re.match(r'([-+]?\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)Z',
                          datetimestr)
         if not match:
-            raise ValueError(u"Invalid format: '%s'" % datetimestr)
+            raise ValueError(u"Invalid format: '{0!s}'".format(datetimestr))
         t = match.groups()
         return cls(long(t[0]), int(t[1]), int(t[2]),
                    int(t[3]), int(t[4]), int(t[5]),


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pywikibot-wikibase?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pywikibot-wikibase?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
